### PR TITLE
Upgraded `renderObject.parent` object to use `RenderObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Upgraded `renderObject.parent` object to use `RenderObject` instead of the deprecated `AbstractNode`. This ensures compatibility and resolves deprecation Flutter v3.12.0-4.0.pre warnings.
+
 ## 1.0.0
 
 * Workaround for Flutter's anti-aliasing issue as https://github.com/flutter/flutter/issues/14288

--- a/lib/src/axis_layout_child.dart
+++ b/lib/src/axis_layout_child.dart
@@ -25,7 +25,7 @@ class AxisLayoutChild extends ParentDataWidget<AxisLayoutParentData> {
   void applyParentData(RenderObject renderObject) {
     assert(renderObject.parentData is AxisLayoutParentData);
     final AxisLayoutParentData parentData =
-        renderObject.parentData! as AxisLayoutParentData;
+    renderObject.parentData! as AxisLayoutParentData;
     bool needsLayout = false;
 
     if (parentData.expand != expand) {
@@ -43,8 +43,9 @@ class AxisLayoutChild extends ParentDataWidget<AxisLayoutParentData> {
       parentData.shrinkOrder = shrinkOrder;
       needsLayout = true;
     }
+
     if (needsLayout) {
-      final AbstractNode? targetParent = renderObject.parent;
+      final RenderObject? targetParent = renderObject.parent;
       if (targetParent is RenderObject) {
         targetParent.markNeedsLayout();
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: axis_layout
 description: Horizontal (row) and vertical (column) layout with expand and shrink features.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/caduandrade/axis_layout_flutter
 
 environment:


### PR DESCRIPTION
Upgraded `renderObject.parent` object to use `RenderObject` instead of the deprecated `AbstractNode`. 


This ensures compatibility and resolves deprecation Flutter v3.12.0-4.0.pre warnings.


This PR fixes such exceptions:

```
../../.pub-cache/hosted/pub.dev/axis_layout-1.0.0/lib/src/axis_layout_child.dart:47:55: Error: A value of type 'RenderObject?' can't be assigned to a variable of type 'AbstractNode?'.
 - 'RenderObject' is from 'package:flutter/src/rendering/object.dart' ('../../packages/flutter/lib/src/foundation/node.dart').
 - 'AbstractNode' is from 'package:flutter/src/foundation/node.dart' ('../../packages/flutter/lib/src/foundation/node.dart').
      final AbstractNode? targetParent = renderObject.parent;
                                                      ^
../../.pub-cache/hosted/pub.dev/axis_layout-1.0.0/lib/src/axis_layout_child.dart:49:22: Error: The method 'markNeedsLayout' isn't defined for the class 'AbstractNode?'.
 - 'AbstractNode' is from 'package:flutter/src/foundation/node.dart' ('../../packages/flutter/lib/src/foundation/node.dart').
Try correcting the name to the name of an existing method, or defining a method named 'markNeedsLayout'.
        targetParent.markNeedsLayout();
```